### PR TITLE
remove partial order requirement for IRValueRef

### DIFF
--- a/tpde/include/tpde/IRAdaptor.hpp
+++ b/tpde/include/tpde/IRAdaptor.hpp
@@ -109,7 +109,7 @@ concept IRAdaptor = requires(T a) {
   requires requires(typename T::IRValueRef r, typename T::IRValueRef w) {
     { r == T::INVALID_VALUE_REF } -> std::convertible_to<bool>;
     { r != T::INVALID_VALUE_REF } -> std::convertible_to<bool>;
-    { r < w } -> std::convertible_to<bool>;
+    // { r < w } -> std::convertible_to<bool>;
   };
 
 


### PR DESCRIPTION
The `mlir::Value` type does not supply a comparison operation, meaning it does not fulfill the partial order requirement (unnecessarily) enforced by TPDE. This PR removes that unnecessary requirement.
